### PR TITLE
Fix small brain mistake in format check

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,7 +223,7 @@ client.on('message', message => {
 				}
                 console.log("bot checked",message.id);
             }
-            else if (attEx == "mkv" || attEx == "avi" || attEx == "mpg" || attEx == "m4v" || attEx = "wmv" || attEx = "mxf" || attEx = "y4m") {
+            else if (attEx == "mkv" || attEx == "avi" || attEx == "mpg" || attEx == "m4v" || attEx == "wmv" || attEx == "mxf" || attEx == "y4m") {
 				var convertTip = "OBS Studio can convert MKV to MP4.\nGo to File -> Remux Recordings.";
 				if (attEx != "mkv"){
 					convertTip = "Use FFmpeg or Handbrake to convert your " + attEx + " video\nto MP4, WebM, or MOV format. *Avoid online tools.*";


### PR DESCRIPTION
My one brain cell seems to have missed the fact that I put an = sign instead of == for the format check against WMV, MXF, and Y4M files. This change corrects that.